### PR TITLE
chore(ci): auto-deploy to Hostinger on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy to Hostinger
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:      # allows manual re-run from the Actions tab
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # This repo holds pre-built files (no npm build step needed).
+      # Uploads index.html and assets/ to the Hostinger site root.
+      - name: Deploy via FTP
+        uses: SamKirkland/FTP-Deploy-Action@v4.4.0
+        with:
+          server: ${{ secrets.HOSTINGER_FTP_SERVER }}
+          username: ${{ secrets.HOSTINGER_FTP_USER }}
+          password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
+          protocol: ftps
+          local-dir: ./
+          server-dir: ./
+          exclude: |
+            **/.git*
+            **/.git*/**
+            **/.github/**
+            **/node_modules/**
+            source_files/**
+            LICENSE
+            README.md
+            *.md


### PR DESCRIPTION
## Summary
- joshuaedwards.me currently requires manually updating files in hPanel; merges to main only updated GitHub Pages, not the live domain.

## Changes
- Added `.github/workflows/deploy.yml`: on every push to main (or manual dispatch from the Actions tab), uploads `index.html` and `assets/` to Hostinger via FTPS using `SamKirkland/FTP-Deploy-Action@v4.4.0` — the same pattern as the working supremedetailing pipeline, minus the build step (this repo holds pre-built files).
- Excludes repo-only files (git internals, `source_files/`, README, LICENSE, markdown notes).

## Impact
- Once the three repo secrets are added (`HOSTINGER_FTP_SERVER`, `HOSTINGER_FTP_USER`, `HOSTINGER_FTP_PASSWORD`), every merge to main deploys joshuaedwards.me automatically.
- The workflow will fail until those secrets exist — expected.

## Testing
- Pattern copied from the proven supremedetailing workflow; action version verified as the latest release (v4.4.0, Apr 2026). Live verification after secrets are added.

## Notes
- `server-dir` is `./` to match the supremedetailing setup; if the FTP account for joshuaedwards.me lands above the web root, change it to `./public_html/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)