### PR TITLE
fix(ci): deploy into public_html instead of FTP account root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,7 @@ jobs:
           password: ${{ secrets.HOSTINGER_FTP_PASSWORD }}
           protocol: ftps
           local-dir: ./
-          server-dir: ./
+          server-dir: ./public_html/
           exclude: |
             **/.git*
             **/.git*/**


### PR DESCRIPTION
## Summary
- The first deploy run reported `Server Files: 0` and synced into an empty directory — the FTP account root is one level above the web root, so joshuaedwards.me kept serving the old files.

## Changes
- `server-dir` changed from `./` to `./public_html/`.

## Impact
- Deploys land in the actual web root. The six stray files/folders from the first run remain in the FTP account root and can be deleted via hPanel file manager.

## Testing
- Verified via run 28681879989 logs (`Server Files: 0`) and the absence of `.ftp-deploy-sync-state.json` on the live site. Will verify the fix by watching the deploy triggered by this merge.

## Notes
- n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)