### PR TITLE
feat(seo): add meta description to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Joshua Edwards</title>
+    <meta name="description" content="Joshua Edwards - software developer and systems builder in Colorado Springs. Full-stack, AWS automation, and team leadership." />
     <link rel="icon" href="/assets/josh.S4J4sZk1.jpg" />
     <link rel="stylesheet" href="/assets/main.XmzKaM6d.css" />
   </head>


### PR DESCRIPTION
## Summary
- No meta description existed; search engines improvise one. Also serves as the observable probe for verifying Hostinger's GitHub-App auto-deploy.

## Changes
- Added a meta description tag to `index.html`.

## Impact
- Controlled search-result snippet for joshuaedwards.me.

## Testing
- Curling the live site after merge to confirm auto-deploy with zero manual action.

## Notes
- n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)